### PR TITLE
telephony: Add backwards compatibility with pre-oreo blobs (2/2)

### DIFF
--- a/src/com/android/phone/PhoneInterfaceManager.java
+++ b/src/com/android/phone/PhoneInterfaceManager.java
@@ -2320,6 +2320,10 @@ public class PhoneInterfaceManager extends ITelephony.Stub {
         }
     }
 
+    public boolean hasIccCardUsingSlotId(int slotId) {
+       return hasIccCardUsingSlotIndex(slotId);
+    }
+
     /**
      * Return if the current radio is LTE on CDMA. This
      * is a tri-state return value as for a period of time


### PR DESCRIPTION
13bac7bc86cbfca9d9508ae3e4c3facfd514bbe3 changed id and idx to index
however, pre-oreo blobs still call the id and idx functions. Add the
old function names and just point to the new functions.

Change-Id: I88a241025a281712c3fbfdff153b4476a6fb1c5f